### PR TITLE
Update tasks and templates to support different Solana networks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,5 @@ download_snapshot: "true"
 swap_mb: "100000"
 solana_installer: "true"
 base_path: /home/mnt
+solana_network: mainnet
+solana_index_exclude_keys: []

--- a/tasks/file_setup.yaml
+++ b/tasks/file_setup.yaml
@@ -1,3 +1,8 @@
+- name: Gather variables per solana network
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ solana_network | lower }}-defaults.yaml"
+
 - name: sol validator setup
   become: true
   become_user: solana
@@ -12,7 +17,7 @@
   become: true
   become_user: root
   template:
-    src: sol.service
+    src: sol.service.j2
     dest: /etc/systemd/system/sol.service
     owner: root
     group: root

--- a/tasks/snapshot_downloader.yaml
+++ b/tasks/snapshot_downloader.yaml
@@ -10,4 +10,4 @@
 - name: download latest snapshot
   become: true
   become_user: solana
-  shell: python3 {{ base_path }}/snapshot-finder.py --snapshot_path {{ base_path }}/solana-snapshots --version {{ solana_version }}
+  shell: python3 {{ base_path }}/snapshot-finder.py --snapshot_path {{ base_path }}/solana-snapshots --version {{ solana_version }} --rpc_address {{ solana_rpc }}

--- a/templates/sol.service.j2
+++ b/templates/sol.service.j2
@@ -11,7 +11,7 @@ LimitNOFILE=1000000
 LogRateLimitIntervalSec=0
 User=solana
 Environment=PATH=/bin:/usr/bin:/home/solana/.local/share/solana/install/active_release/bin
-Environment=SOLANA_METRICS_CONFIG=host=https://metrics.solana.com:8086,db=mainnet-beta,u=mainnet-beta_write,p=password
+Environment=SOLANA_METRICS_CONFIG={{ solana_metrics_config }}
 ExecStart=/home/solana/validator.sh
 
 [Install]

--- a/templates/validator.j2
+++ b/templates/validator.j2
@@ -28,11 +28,7 @@ exec solana-validator \
   --enable-cpi-and-log-storage \
   --enable-rpc-transaction-history \
   --account-index program-id spl-token-mint spl-token-owner \
-  --accounts-index-memory-limit-mb 800000 \
 {% for key in solana_index_exclude_keys %}
   --account-index-exclude-key {{ key }} \
 {% endfor %}
-{% for validator in solana_known_validators %}
-  --known-validator {{ validator }} {% if not loop.last %}\
-{% endif %}
-{% endfor %}
+  --accounts-index-memory-limit-mb 800000

--- a/templates/validator.j2
+++ b/templates/validator.j2
@@ -6,11 +6,9 @@ PATH=/home/solana/.local/share/solana/install/active_release/bin:/usr/sbin:/usr/
 # Start solana rpc node, intended to be used with journalctl/systemctl. Logs will go to journalctl.
 exec solana-validator \
   --identity /home/solana/rpc_node.json \
-    --entrypoint entrypoint.mainnet-beta.solana.com:8001 \
-    --entrypoint entrypoint2.mainnet-beta.solana.com:8001 \
-    --entrypoint entrypoint3.mainnet-beta.solana.com:8001 \
-    --entrypoint entrypoint4.mainnet-beta.solana.com:8001 \
-    --entrypoint entrypoint5.mainnet-beta.solana.com:8001 \
+{% for entrypoint in solana_entrypoints %}
+  --entrypoint {{ entrypoint }} \
+{% endfor %}
   --accounts /home/mnt/solana-accounts \
   --ledger /home/mnt/solana-ledger \
   --snapshots /home/mnt/solana-snapshots \
@@ -31,5 +29,10 @@ exec solana-validator \
   --enable-rpc-transaction-history \
   --account-index program-id spl-token-mint spl-token-owner \
   --accounts-index-memory-limit-mb 800000 \
-  --account-index-exclude-key TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA \
-  --account-index-exclude-key kinXdEcpDQeHPEuQnqmUgtYykqKGVFq6CeVX5iAHJq6
+{% for key in solana_index_exclude_keys %}
+  --account-index-exclude-key {{ key }} \
+{% endfor %}
+{% for validator in solana_known_validators %}
+  --known-validator {{ validator }} {% if not loop.last %}\
+{% endif %}
+{% endfor %}

--- a/vars/devnet-defaults.yaml
+++ b/vars/devnet-defaults.yaml
@@ -8,9 +8,3 @@ solana_entrypoints:
   - entrypoint5.devnet.solana.com:8001
 
 solana_metrics_config: host=https://metrics.solana.com:8086,db=devnet,u=scratch_writer,p=topsecret
-
-solana_known_validators:
-  - dv1ZAGvdsz5hHLwWXsVnM94hWf1pjbKVau1QVkaMJ92
-  - dv2eQHeP4RFrJZ6UeiZWoc3XTtmtZCUKxxCApCDcRNV
-  - dv4ACNkpYPcE3aKmYDqZm9G5EB3J4MRoeE7WNDRBVJB
-  - dv3qDFk1DTF36Z62bNvrCXe9sKATA6xvVy6A798xxAS

--- a/vars/devnet-defaults.yaml
+++ b/vars/devnet-defaults.yaml
@@ -1,0 +1,16 @@
+solana_rpc: https://api.devnet.solana.com
+
+solana_entrypoints:
+  - entrypoint.devnet.solana.com:8001
+  - entrypoint2.devnet.solana.com:8001
+  - entrypoint3.devnet.solana.com:8001
+  - entrypoint4.devnet.solana.com:8001
+  - entrypoint5.devnet.solana.com:8001
+
+solana_metrics_config: host=https://metrics.solana.com:8086,db=devnet,u=scratch_writer,p=topsecret
+
+solana_known_validators:
+  - dv1ZAGvdsz5hHLwWXsVnM94hWf1pjbKVau1QVkaMJ92
+  - dv2eQHeP4RFrJZ6UeiZWoc3XTtmtZCUKxxCApCDcRNV
+  - dv4ACNkpYPcE3aKmYDqZm9G5EB3J4MRoeE7WNDRBVJB
+  - dv3qDFk1DTF36Z62bNvrCXe9sKATA6xvVy6A798xxAS

--- a/vars/mainnet-defaults.yaml
+++ b/vars/mainnet-defaults.yaml
@@ -12,9 +12,3 @@ solana_metrics_config: host=https://metrics.solana.com:8086,db=mainnet-beta,u=ma
 solana_index_exclude_keys:
   - 'kinXdEcpDQeHPEuQnqmUgtYykqKGVFq6CeVX5iAHJq6'
   - 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
-
-solana_known_validators:
-  - 7Np41oeYqPefeNQEHSv1UDhYrehxin3NStELsSKCT4K2
-  - GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ
-  - DE1bawNcRJB9rVm3buyMVfr8mBEoyyu73NBovf2oXJsJ
-  - CakcnaRDHka2gXyfbEd2d3xsvkJkqsLw2akB3zsN1D2S

--- a/vars/mainnet-defaults.yaml
+++ b/vars/mainnet-defaults.yaml
@@ -1,0 +1,20 @@
+solana_rpc: https://api.mainnet-beta.solana.com
+
+solana_entrypoints:
+  - entrypoint.mainnet-beta.solana.com:8001
+  - entrypoint2.mainnet-beta.solana.com:8001
+  - entrypoint3.mainnet-beta.solana.com:8001
+  - entrypoint4.mainnet-beta.solana.com:8001
+  - entrypoint5.mainnet-beta.solana.com:8001
+
+solana_metrics_config: host=https://metrics.solana.com:8086,db=mainnet-beta,u=mainnet-beta_write,p=password
+
+solana_index_exclude_keys:
+  - 'kinXdEcpDQeHPEuQnqmUgtYykqKGVFq6CeVX5iAHJq6'
+  - 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+
+solana_known_validators:
+  - 7Np41oeYqPefeNQEHSv1UDhYrehxin3NStELsSKCT4K2
+  - GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ
+  - DE1bawNcRJB9rVm3buyMVfr8mBEoyyu73NBovf2oXJsJ
+  - CakcnaRDHka2gXyfbEd2d3xsvkJkqsLw2akB3zsN1D2S

--- a/vars/testnet-defaults.yaml
+++ b/vars/testnet-defaults.yaml
@@ -6,9 +6,3 @@ solana_entrypoints:
   - entrypoint3.testnet.solana.com:8001
 
 solana_metrics_config: host=https://metrics.solana.com:8086,db=tds,u=testnet_write,p=c4fa841aa918bf8274e3e2a44d77568d9861b3ea
-
-solana_known_validators:
-  - 5D1fNXzvv5NjV1ysLjirC4WY92RNsVH18vjmcszZd8on
-  - 7XSY3MrYnK8vq693Rju17bbPkCN3Z7KvvfvJx4kdrsSY
-  - Ft5fbkqNa76vnsjYNwjDZUXoTWpP7VYm3mtsaQckQADN
-  - 9QxCLckBiJc783jnMvXZubK4wH86Eqqvashtrwvcsgkv

--- a/vars/testnet-defaults.yaml
+++ b/vars/testnet-defaults.yaml
@@ -1,0 +1,14 @@
+solana_rpc: https://api.testnet.solana.com
+
+solana_entrypoints:
+  - entrypoint.testnet.solana.com:8001
+  - entrypoint2.testnet.solana.com:8001
+  - entrypoint3.testnet.solana.com:8001
+
+solana_metrics_config: host=https://metrics.solana.com:8086,db=tds,u=testnet_write,p=c4fa841aa918bf8274e3e2a44d77568d9861b3ea
+
+solana_known_validators:
+  - 5D1fNXzvv5NjV1ysLjirC4WY92RNsVH18vjmcszZd8on
+  - 7XSY3MrYnK8vq693Rju17bbPkCN3Z7KvvfvJx4kdrsSY
+  - Ft5fbkqNa76vnsjYNwjDZUXoTWpP7VYm3mtsaQckQADN
+  - 9QxCLckBiJc783jnMvXZubK4wH86Eqqvashtrwvcsgkv


### PR DESCRIPTION
Supporting different Solana networks required a some changes to the service template, the snapshot downloader task, and the validator template. Now you can set the `solana_network` variable to either: `devnet`, `testnet`, or `mainnet` (default).